### PR TITLE
feat : kakao 로그인/로그아웃/토큰갱신 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
     // JsonObject
     implementation 'org.json:json:20220924'
+
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ecloth/beta/BetaApplication.java
+++ b/src/main/java/com/ecloth/beta/BetaApplication.java
@@ -2,7 +2,6 @@ package com.ecloth.beta;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class BetaApplication {

--- a/src/main/java/com/ecloth/beta/common/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/ecloth/beta/common/jwt/JwtTokenUtil.java
@@ -11,9 +11,14 @@ import java.time.Duration;
 public class JwtTokenUtil {
     private final RedisTemplate<String, String> redisTemplate;;
 
-    // 로그아웃시 RefreshToken 삭제
+    // 로그아웃시 JWT RefreshToken 삭제
     public void deleteRefreshToken(String email) {
         redisTemplate.delete("RT:" + email);
+    }
+
+    // 로그아웃시 kakao RefreshToken 삭제
+    public void deleteKakaoRefreshToken(String email){
+        redisTemplate.delete("KRT:" + email);
     }
 
     // 삭제된 토큰 Blacklist 처리

--- a/src/main/java/com/ecloth/beta/common/security/MemberDetailService.java
+++ b/src/main/java/com/ecloth/beta/common/security/MemberDetailService.java
@@ -2,7 +2,7 @@ package com.ecloth.beta.common.security;
 
 import com.ecloth.beta.member.entity.Member;
 import com.ecloth.beta.member.exception.ErrorCode;
-import com.ecloth.beta.member.exception.GlobalCustomException;
+import com.ecloth.beta.member.exception.MemberException;
 import com.ecloth.beta.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -18,7 +18,7 @@ public class MemberDetailService implements UserDetailsService {
     @Override
     public MemberDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(()->new GlobalCustomException(ErrorCode.NOT_FOUND_USER));
+                .orElseThrow(()->new MemberException(ErrorCode.NOT_FOUND_USER));
 
         return new MemberDetails(member);
     }

--- a/src/main/java/com/ecloth/beta/member/controller/OauthController.java
+++ b/src/main/java/com/ecloth/beta/member/controller/OauthController.java
@@ -1,0 +1,33 @@
+package com.ecloth.beta.member.controller;
+
+import com.ecloth.beta.member.dto.OauthToken;
+import com.ecloth.beta.member.service.OauthService;
+import io.swagger.annotations.Api;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@AllArgsConstructor
+@Api(tags = "카카오 로그인 API")
+public class OauthController {
+
+    private final OauthService oAuthService;
+
+    // 프론트에서 인가코드 받기
+    @GetMapping("/KakaoLogin")
+    public ResponseEntity<Void> kakaoLogin(@RequestParam("code") String authCode) {
+        log.info("카카오 authcode 받음 : " + authCode);
+
+        OauthToken oauthToken = oAuthService.getKakaoToken(authCode);
+        HttpHeaders headers = oAuthService.kakaoRegisterAndGetToken(oauthToken.getAccess_token());
+
+        return ResponseEntity.ok().headers(headers).build();
+    }
+
+}

--- a/src/main/java/com/ecloth/beta/member/dto/KakaoProfileRequest.java
+++ b/src/main/java/com/ecloth/beta/member/dto/KakaoProfileRequest.java
@@ -1,0 +1,46 @@
+package com.ecloth.beta.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoProfileRequest {
+
+    public Long id;
+    public String connected_at;
+    public Properties properties;
+    public KakaoAccount kakao_account;
+
+    @Getter
+    @Setter
+    public static class Properties {
+        public String nickname;
+        public String profile_image;
+        public String thumbnail_image;
+    }
+
+    @Getter
+    @Setter
+    public static class KakaoAccount {
+        public Boolean profile_nickname_needs_agreement;
+        public Boolean profile_image_needs_agreement;
+        public Profile profile;
+        public Boolean has_email;
+        public Boolean email_needs_agreement;
+        public Boolean is_email_valid;
+        public Boolean is_email_verified;
+        public String email;
+
+        @Getter
+        @Setter
+        public static class Profile {
+            public String nickname;
+            public String thumbnail_image_url;
+            public String profile_image_url;
+            public Boolean is_default_image;
+        }
+    }
+}

--- a/src/main/java/com/ecloth/beta/member/dto/OauthToken.java
+++ b/src/main/java/com/ecloth/beta/member/dto/OauthToken.java
@@ -1,0 +1,17 @@
+package com.ecloth.beta.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OauthToken {
+
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+    private String id_token;
+}

--- a/src/main/java/com/ecloth/beta/member/exception/MemberException.java
+++ b/src/main/java/com/ecloth/beta/member/exception/MemberException.java
@@ -3,10 +3,10 @@ package com.ecloth.beta.member.exception;
 import lombok.Getter;
 
 @Getter
-public class GlobalCustomException extends RuntimeException {
+public class MemberException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public GlobalCustomException(ErrorCode errorCode) {
+    public MemberException(ErrorCode errorCode) {
         super(errorCode.getDetail());
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/ecloth/beta/member/model/MemberRole.java
+++ b/src/main/java/com/ecloth/beta/member/model/MemberRole.java
@@ -2,7 +2,6 @@ package com.ecloth.beta.member.model;
 
 public enum MemberRole {
     ROLE_MEMBER,
-    ROLE_OAUTH_MEMBER,
-    ROLE_ADMIN
+    ROLE_OAUTH_MEMBER
 }
 

--- a/src/main/java/com/ecloth/beta/member/service/MemberService.java
+++ b/src/main/java/com/ecloth/beta/member/service/MemberService.java
@@ -1,18 +1,19 @@
 package com.ecloth.beta.member.service;
 
+import com.ecloth.beta.common.jwt.JwtTokenProvider;
+import com.ecloth.beta.common.jwt.JwtTokenUtil;
 import com.ecloth.beta.member.component.JavaMailSenderComponent;
+import com.ecloth.beta.member.dto.InfoMeRequest;
 import com.ecloth.beta.member.dto.MemberRequest;
 import com.ecloth.beta.member.dto.Token;
 import com.ecloth.beta.member.entity.Member;
 import com.ecloth.beta.member.exception.ErrorCode;
-import com.ecloth.beta.member.exception.GlobalCustomException;
-import com.ecloth.beta.common.jwt.JwtTokenProvider;
-import com.ecloth.beta.common.jwt.JwtTokenUtil;
+import com.ecloth.beta.member.exception.MemberException;
 import com.ecloth.beta.member.model.MemberRole;
 import com.ecloth.beta.member.model.MemberStatus;
 import com.ecloth.beta.member.repository.MemberRepository;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
@@ -23,14 +24,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
 @Slf4j
 @Transactional
-@AllArgsConstructor
 @Builder
+@RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -38,17 +40,18 @@ public class MemberService {
     private final JavaMailSenderComponent javaMailSenderComponent;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenUtil jwtTokenUtil;
-    private final RedisTemplate<String,String> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final OauthService oauthService;
 
     @Transactional
     public Member register(MemberRequest.Register RegisterDto) {
         // 이메일 중복 체크
         if (memberRepository.existsByEmail(RegisterDto.getEmail())) {
-            throw new GlobalCustomException(ErrorCode.ALREADY_EXIST_EMAIL);
+            throw new MemberException(ErrorCode.ALREADY_EXIST_EMAIL);
         }
         // 닉네임 중복 체크
         if (memberRepository.existsByNickname(RegisterDto.getNickname())) {
-            throw new GlobalCustomException(ErrorCode.ALREADY_EXIST_NICKNAME);
+            throw new MemberException(ErrorCode.ALREADY_EXIST_NICKNAME);
         }
         // 이메일 인증 코드 생성
         String emailAuthCode = UUID.randomUUID().toString().replace("-", "");
@@ -78,7 +81,7 @@ public class MemberService {
     // 이메일 인증 완료 후, 멤버 정보를 업데이트하는 메소드
     public void updateMemberAfterEmailAuth(String emailAuthCode) {
         Member member = memberRepository.findByEmailAuthCode(emailAuthCode)
-                .orElseThrow(() -> new GlobalCustomException(ErrorCode.INVALID_EMAIL_AUTH_CODE));
+                .orElseThrow(() -> new MemberException(ErrorCode.INVALID_EMAIL_AUTH_CODE));
 
         // 이메일 인증 완료 후, 멤버 정보 업데이트
         member = member.toBuilder()
@@ -94,10 +97,10 @@ public class MemberService {
     public HttpHeaders login(MemberRequest.Login loginDto) {
         // 이메일 검증
         Member member = memberRepository.findByEmail(loginDto.getEmail())
-                .orElseThrow(() -> new GlobalCustomException(ErrorCode.NOT_FOUND_USER));
+                .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_USER));
         // 비밀번호 검증
         if (!passwordEncoder.matches(loginDto.getPassword(), member.getPassword())) {
-            throw new GlobalCustomException(ErrorCode.WRONG_PASSWORD);
+            throw new MemberException(ErrorCode.WRONG_PASSWORD);
         }
         // AccessToken, Refresh Token 생성하기
         Token token = jwtTokenProvider.generateToken(member.getEmail());
@@ -107,8 +110,8 @@ public class MemberService {
 
         // AccessToken과 RefreshToken Http Header에 담아 반환하기
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + token.getAccessToken());
-        headers.add("RefreshToken", "Bearer " + token.getRefreshToken());
+        headers.add("authorization", "Bearer " + token.getAccessToken());
+        headers.add("refreshtoken", "Bearer " + token.getRefreshToken());
         return headers;
     }
 
@@ -116,47 +119,118 @@ public class MemberService {
     public HttpHeaders reissueToken(String requestRT) {
         // "Bearer " 제거
         requestRT = requestRT.replace("Bearer ", "");
-        // request RefreshToken 검증
-        if (!jwtTokenProvider.validateToken(requestRT)) {
-            throw new GlobalCustomException(ErrorCode.EXPIRED_OR_INVALID_REFRESH_TOKEN);
-        }
-        // request RefreshToken 에서 이메일 가져오기
-        String email = jwtTokenProvider.getEmail(requestRT);
-        // Redis 에서 email 을 키값으로 저장된 RT 가져오기
-        String redisRT = (String) redisTemplate.opsForValue().get("RT:" + email);
-        // request RefreshToken과 Redis의 RefreshToken이 일치하지 않는 경우
-        if (!requestRT.equals(redisRT)) {
-            throw new GlobalCustomException(ErrorCode.EXPIRED_OR_INVALID_REFRESH_TOKEN);
-        }
-
-        // 새로운 토큰 생성
-        Token token = jwtTokenProvider.generateToken(email);
-        // RefreshToken Redis에 업데이트
-        redisTemplate.opsForValue()
-                .set("RT:" + email, token.getRefreshToken()
-                        , token.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+        // SecurityContext 에서 현재 인증 객체 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // User email,role  가져오기
+        String email = authentication.getName();
+        String role = authentication.getAuthorities().toString();
+        log.info("토큰갱신요청 사용자 이메일 : " + email);
+        log.info("토큰갱신요청 사용자 역할 : " + role);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + token.getAccessToken());
-        headers.add("RefreshToken", "Bearer " + token.getRefreshToken());
-        return headers;
+
+        // 이메일 회원일경우
+        if (role.equals("[[ROLE_MEMBER]]")) {
+            log.info("ROLE_MEMBER 확인 토큰갱신 진행");
+            // 새로운 토큰 생성
+            Token token = jwtTokenProvider.generateToken(email);
+            // RefreshToken Redis 에 업데이트
+            redisTemplate.opsForValue()
+                    .set("RT:" + email, token.getRefreshToken()
+                            , token.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+            headers.add("authorization", "Bearer " + token.getAccessToken());
+            headers.add("refreshtoken", "Bearer " + token.getRefreshToken());
+            log.info("토큰갱신 AT : " + token.getAccessToken());
+            log.info("토큰갱신 RT : " + token.getRefreshToken());
+            return headers;
+
+            // 카카오 회원일경우
+        } else if (role.equals("[[ROLE_OAUTH_MEMBER]]")) {
+            log.info("ROLE_OAUTH_MEMBER 확인 토큰갱신 진행");
+
+            String redisKRT = redisTemplate.opsForValue().get("KRT:" + email);
+
+            // Redis에서 저장된 kakao RefreshToken 값의 유효시간을 일 단위로 확인
+            Long ttl = redisTemplate.getExpire("KRT:" + email, TimeUnit.DAYS);
+            log.info("Redis key KRT:{} has TTL {} days", email, ttl);
+
+            if (ttl != null && ttl < 30) {
+                // 카카오 RefreshToken 유효기간이 30일 미만일경우 reissueKakaoToken 실행
+                oauthService.reissueKakaoToken(redisKRT, email);
+            }
+
+            // 새로운 JWT토큰 생성
+            Token token = jwtTokenProvider.generateToken(email);
+            // RefreshToken Redis 에 업데이트
+            redisTemplate.opsForValue()
+                    .set("RT:" + email, token.getRefreshToken()
+                            , token.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+            headers.add("authorization", "Bearer " + token.getAccessToken());
+            headers.add("refreshtoken", "Bearer " + token.getRefreshToken());
+
+            return headers;
+
+        } else {
+            throw new RuntimeException("유효하지 않은 회원 유형입니다.");
+        }
     }
 
     public void logout(String accessToken) {
         // "Bearer " 제거
         accessToken = accessToken.replace("Bearer ", "");
-        // SecurityContext에서 현재 인증 객체 가져오기
+        // SecurityContext 에서 현재 인증 객체 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        // User email을 가져오기
+        // User email 을 가져오기
         String email = authentication.getName();
+        String role = authentication.getAuthorities().toString();
 
-        // Redis에서 해당 User email로 저장된 Refresh Token 확인 후 있을 경우 삭제
-        if (redisTemplate.opsForValue().get("RT:" + email) != null) {
-            // 해당 Access Token 유효시간을 가지고 와서 BlackList에 저장
-            Long expiration = jwtTokenProvider.getExpiration(accessToken);
-            jwtTokenUtil.setBlackListToken(email, accessToken, expiration);
-            jwtTokenUtil.deleteRefreshToken(email);
+        // 이메일 회원일경우
+        if (role.equals("[[ROLE_MEMBER]]")) {
+            log.info("ROLE_MEMBER 확인 로그아웃 진행");
+
+            // Redis 에서 해당 User email 로 저장된 Refresh Token 확인 후 있을 경우 삭제
+            if (redisTemplate.opsForValue().get("RT:" + email) != null) {
+                // 해당 Access Token 유효시간을 가지고 와서 BlackList 에 저장
+                Long expiration = jwtTokenProvider.getExpiration(accessToken);
+                jwtTokenUtil.setBlackListToken(email, accessToken, expiration);
+                jwtTokenUtil.deleteRefreshToken(email);
+            }
+        } else if (role.equals("[[ROLE_OAUTH_MEMBER]]")) {
+            log.info("ROLE_OAUTH_MEMBER 확인 로그아웃 진행");
+
+            if (redisTemplate.opsForValue().get("KRT:" + email) != null &&
+                    redisTemplate.opsForValue().get("RT:" + email) != null) {
+
+                // 해당 JWT Access Token 유효시간을 가지고 와서 BlackList 에 저장
+                Long expiration = jwtTokenProvider.getExpiration(accessToken);
+                jwtTokenUtil.setBlackListToken(email, accessToken, expiration);
+                jwtTokenUtil.deleteRefreshToken(email);
+
+                // KRT 삭제
+                jwtTokenUtil.deleteKakaoRefreshToken(email);
+
+            }
         }
+    }
+
+    // 회원 정보 조회
+    public InfoMeRequest getInfoMe() {
+        // SecurityContext 에서 현재 인증 객체 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // User email  가져오기
+        String email = authentication.getName();
+        Optional<Member> member = memberRepository.findByEmail(email);
+        if (member.isEmpty()) {
+            throw new MemberException(ErrorCode.NOT_FOUND_USER);
+        }
+        return InfoMeRequest.builder()
+                .email(member.get().getEmail())
+                .nickname(member.get().getNickname())
+                .phone(member.get().getPhone())
+                .profileImagePath(member.get().getProfileImagePath())
+                .build();
     }
 
 }

--- a/src/main/java/com/ecloth/beta/member/service/OauthService.java
+++ b/src/main/java/com/ecloth/beta/member/service/OauthService.java
@@ -1,0 +1,226 @@
+package com.ecloth.beta.member.service;
+
+
+import com.ecloth.beta.common.jwt.JwtTokenProvider;
+import com.ecloth.beta.member.dto.KakaoProfileRequest;
+import com.ecloth.beta.member.dto.OauthToken;
+import com.ecloth.beta.member.dto.Token;
+import com.ecloth.beta.member.entity.Member;
+import com.ecloth.beta.member.model.MemberRole;
+import com.ecloth.beta.member.model.MemberStatus;
+import com.ecloth.beta.member.repository.MemberRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Map<String, OauthToken> oauthTokenMap = new ConcurrentHashMap<>();
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+
+    // 카카오 서버에서 토큰 받아오기
+    @Transactional
+    public OauthToken getKakaoToken(String code) {
+        log.info("authCode를 통해 getKakaoToken 메서드 들어옴");
+        // HttpHeader 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HttpBody 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+        body.add("client_secret", clientSecret);
+
+        // HttpHeader와 HttpBody 를 HttpEntity 객체에 담아 요청
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> KakaoTokenResponse = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // Http 응답, 응답값 파싱
+        ObjectMapper objectMapper = new ObjectMapper();
+        OauthToken oauthToken;
+        try {
+            oauthToken = objectMapper.readValue(KakaoTokenResponse.getBody(), OauthToken.class);
+            oauthTokenMap.put(oauthToken.getAccess_token(), oauthToken); //임시저장
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        log.info("해시맵 저장 : " + oauthTokenMap.get(oauthToken.getAccess_token()));
+        log.info("카카오AT : " + oauthToken.getAccess_token());
+        log.info("카카오RT : " + oauthToken.getRefresh_token());
+
+        return oauthToken;
+
+    }
+
+    // 로그인 & JWT 토큰발급
+    @Transactional
+    public HttpHeaders kakaoRegisterAndGetToken(String token) {
+        log.info("kakaoRegisterAndGetToken 들어옴");
+        // 유저정보 받기
+        KakaoProfileRequest userInfo = getUserInfo(token);
+        // 최초 로그인시 회원정보 저장
+        memberRepository.findByEmail(userInfo.getKakao_account().getEmail())
+                .orElseGet(() -> {
+
+                    Member kakaoNewMember = Member.builder()
+                            .email(userInfo.getKakao_account().getEmail())
+                            .nickname(userInfo.getProperties().getNickname())
+                            .profileImagePath(userInfo.getProperties().getProfile_image())
+                            .memberRole(MemberRole.ROLE_OAUTH_MEMBER)
+                            .memberStatus(MemberStatus.ACTIVE)
+                            .build();
+
+                    log.info("사이트 최초 로그인 회원정보저장");
+                    return memberRepository.save(kakaoNewMember);
+                });
+        // JWT 토큰 생성
+        Token jwtDto = jwtTokenProvider.generateToken(userInfo.getKakao_account().getEmail());
+        // Redis 에 JWT Refresh 토큰 저장
+        redisTemplate.opsForValue()
+                .set("RT:" + userInfo.getKakao_account().getEmail(),
+                        jwtDto.getRefreshToken(), jwtDto.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+        // Redis 에 Kakao Refresh 토큰 저장
+        log.info("kakaoRegisterAndGetToken 에서 oauthTokenMap 을 이용해 Redis 저장위한 액토 리토 불러오기");
+
+        // oauthTokenMap 에서 정보를 불러와 Redis 저장에 사용
+        OauthToken oauthToken = oauthTokenMap.get(token);
+        log.info("해시맵에서 불러온 주소 : " + oauthTokenMap.get(token));
+
+        redisTemplate.opsForValue()
+                .set("KRT:" + userInfo.getKakao_account().getEmail(),
+                        oauthToken.getRefresh_token(), oauthToken.getRefresh_token_expires_in(), TimeUnit.SECONDS);
+        oauthTokenMap.remove(token); //Redis에 저장 후 oauthTokenMap에 담긴 정보 삭제
+        log.info("해시맵정보 레디스 저장후 삭제 확인 null : " + oauthTokenMap.get(token));
+
+        // JWT AccessToken과 RefreshToken Http Header에 담아 반환하기
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("authorization", "Bearer " + jwtDto.getAccessToken());
+        headers.add("refreshtoken", "Bearer " + jwtDto.getRefreshToken());
+
+        log.info("jwt AT : " + jwtDto.getAccessToken());
+        log.info("jwt RT : " + jwtDto.getRefreshToken());
+        log.info("kakao Redis RT : " + oauthToken.getRefresh_token());
+
+        return headers;
+    }
+
+    // 유저 정보 가져오기
+    @Transactional
+    public KakaoProfileRequest getUserInfo(String token) {
+        log.info("kakaoRegisterAndGetToken 에서 token을 통해 getUserInfo 메서드 들어옴");
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> kakaoUserResponse = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
+
+        // Http 응답, 유저 정보 파싱
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoProfileRequest kakaoUserInfo;
+        try {
+            kakaoUserInfo = objectMapper.readValue(kakaoUserResponse.getBody(), KakaoProfileRequest.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        log.info("Kakao User Response Body: " + kakaoUserResponse.getBody());
+
+        log.info("카카오 이메일 : " + kakaoUserInfo.getKakao_account().getEmail());
+        log.info("카카오 닉네임 : " + kakaoUserInfo.getProperties().getNickname());
+        log.info("카카오 프로필 : " + kakaoUserInfo.getProperties().getProfile_image());
+
+        return kakaoUserInfo;
+    }
+
+    // 카카오 토큰 갱신
+    @Transactional
+    public void reissueKakaoToken(String redisKRT, String email) {
+        // HttpHeader 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HttpBody 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "refresh_token");
+        body.add("client_id", clientId);
+        body.add("refresh_token", redisKRT);
+        body.add("client_secret", clientSecret);
+
+        // HttpHeader와 HttpBody 를 HttpEntity 객체에 담아 요청
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> KakaoTokenResponse = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // Http 응답, 응답값 파싱
+        ObjectMapper objectMapper = new ObjectMapper();
+        OauthToken oauthToken;
+        try {
+            oauthToken = objectMapper.readValue(KakaoTokenResponse.getBody(), OauthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Redis 에 새로운 카카오 RefreshToken 저장
+        redisTemplate.opsForValue()
+                .set("KRT:" + email, oauthToken.getRefresh_token()
+                        , oauthToken.getRefresh_token_expires_in(), TimeUnit.SECONDS);
+        log.info("카카오토큰갱신 AT : " + oauthToken.getAccess_token());
+        log.info("카카오토큰갱신 RT : " + oauthToken.getRefresh_token());
+
+    }
+
+
+}

--- a/src/main/resources/application-develop.properties
+++ b/src/main/resources/application-develop.properties
@@ -49,3 +49,15 @@ spring.redis.port=6379
 
 # query ? 값 추적
 logging.level.org.hibernate.type.descriptor.sql=trace
+
+# OAuth2 - Kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type="authorization_code"
+spring.security.oauth2.client.registration.kakao.client-id=ENC(ARASP2AYBcXol+dhDaXhQAJHkkMNiyb1eJQtsNmrxPAlGH1g7FwNSm/kzvBSzsdT)
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:5173/KakaoLogin
+spring.security.oauth2.client.registration.kakao.client-authentication-method=POST
+spring.security.oauth2.client.registration.kakao.client-secret=ENC(HfYMmm5LNPdzKss50HKtlZyDcoM2cFagPpczFk13gkjZ6M7hhXvVe8wvLbrtx+oO)
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,15 @@ jwt.token.key=ENC(BnvxX9P9L0WgsmWPuqMCQYWO1KvIc8bX7UKjox3tISw=)
 # Redis
 spring.redis.host=localhost
 spring.redis.port=6379
+
+# OAuth2 - Kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type="authorization_code"
+spring.security.oauth2.client.registration.kakao.client-id=ENC(ARASP2AYBcXol+dhDaXhQAJHkkMNiyb1eJQtsNmrxPAlGH1g7FwNSm/kzvBSzsdT)
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:5173/KakaoLogin
+spring.security.oauth2.client.registration.kakao.client-authentication-method=POST
+spring.security.oauth2.client.registration.kakao.client-secret=ENC(HfYMmm5LNPdzKss50HKtlZyDcoM2cFagPpczFk13gkjZ6M7hhXvVe8wvLbrtx+oO)
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id


### PR DESCRIPTION
**Changes**
---
kakao 로그인/로그아웃/토큰갱신 기능 구현
- 최초 로그인시 회원정보 DB에 저장
- Redis 저장 토큰정보
"RT" email : JWT 리프레시토큰
"KRT" email : 카카오 리프레시토큰 
- 토큰 갱신요청시 카카오 토큰은 30일 미만일 경우에만 진행, 그 외는 JWT만 갱신하여 헤더로 응답
- 로그아웃시 Redis에서 JWT 리프레시토큰 블랙리스트처리 ,카카오 리프레시 토큰 삭제처리
카카오 액세스토큰의 경우 이옷어때에서 로그인시를 제외 사용하지 않기 때문에 Redis에서만 삭제처리 

**AS-IS**
- Member 예외 클래스명 변경 GlobalCustomException ->

**TO-BE**
- MemberException

### **테스트**
- [X]  API 테스트 (* 컨트롤러 테스트)