### PR TITLE
fix : post,comment

### DIFF
--- a/src/main/java/com/ecloth/beta/domain/post/comment/dto/CommentListResponse.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/dto/CommentListResponse.java
@@ -1,16 +1,16 @@
 package com.ecloth.beta.domain.post.comment.dto;
 
 import com.ecloth.beta.common.page.CustomPage;
-import com.ecloth.beta.domain.post.comment.entity.Comment;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Page;
+
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Getter
@@ -22,20 +22,17 @@ public class CommentListResponse implements Serializable {
     private long total;
     @Builder.Default
     private CustomPage page = new CustomPage(1, 10, "registerDate", "ASC");
-    private List<CommentResponse> commentList;
+    @Builder.Default
+    private List<CommentResponse> commentList = new ArrayList<>();
 
-    public static CommentListResponse fromEntity(Page<Comment> commentPage) {
+    private CommentListResponse(int total, CustomPage page, List<CommentResponse> commentList) {
+        this.total = total;
+        this.page = page;
+        this.commentList = commentList;
+    }
 
-        CustomPage resultPage = CustomPage.of(commentPage.getPageable());
-
-        return CommentListResponse.builder()
-                .total(commentPage.getTotalElements())
-                .page(resultPage)
-                .commentList(commentPage.getContent().stream()
-                        .map(CommentResponse::fromEntity)
-                        .collect(Collectors.toList())
-                )
-                .build();
+    public static CommentListResponse from(List<CommentResponse> commentList, int total, CustomPage page) {
+        return new CommentListResponse(total, page, commentList != null ? commentList : Collections.emptyList());
     }
 
 }

--- a/src/main/java/com/ecloth/beta/domain/post/comment/dto/CommentResponse.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/dto/CommentResponse.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -26,30 +27,40 @@ public class CommentResponse {
     private LocalDateTime updatedDate;
 
     public static CommentResponse fromEntity(Comment comment, Member writer) {
-        return CommentResponse.builder()
+        CommentResponse.CommentResponseBuilder builder = CommentResponse.builder()
                 .commentId(comment.getCommentId())
                 .writerId(writer.getMemberId())
                 .nickname(writer.getNickname())
                 .profileImagePath(writer.getProfileImagePath())
                 .content(comment.getContent())
-                .reply(ReplyResponse.fromEntity(comment.getReply()))
                 .registerDate(comment.getRegisterDate())
-                .updatedDate(comment.getUpdateDate())
-                .build();
+                .updatedDate(comment.getUpdateDate());
+
+        Reply reply = comment.getReply();
+        if (reply != null) {
+            builder.reply(ReplyResponse.fromEntity(reply));
+        }
+
+        return builder.build();
     }
 
     public static CommentResponse fromEntity(Comment comment) {
-        return CommentResponse.builder()
+        CommentResponse.CommentResponseBuilder builder = CommentResponse.builder()
                 .commentId(comment.getCommentId())
                 .writerId(comment.getWriter().getMemberId())
                 .nickname(comment.getWriter().getNickname())
                 .profileImagePath(comment.getWriter().getProfileImagePath())
                 .content(comment.getContent())
-                .reply(ReplyResponse.fromEntity(comment.getReply()))
                 .registerDate(comment.getRegisterDate())
-                .updatedDate(comment.getUpdateDate())
-                .build();
-    }
+                .updatedDate(comment.getUpdateDate());
 
+        if (comment.getReply() != null) {
+            builder.reply(ReplyResponse.fromEntity(comment.getReply()));
+        } else {
+            builder.reply(null); // reply 필드가 null인 경우에는 null로 설정
+        }
+
+        return builder.build();
+    }
 }
 

--- a/src/main/java/com/ecloth/beta/domain/post/comment/exception/ErrorCode.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND("해당 댓글은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     REPLY_NOT_FOUND("해당 대댓글은 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     POSTING_WRITER_REPLY_WRITER_NOT_MATCHING("포스트 작성자만 대댓글을 달 수 있습니다.", HttpStatus.BAD_REQUEST),
-    NOT_REPLY_WRITER("대댓글 작성자만 수정할 수 있습니다.", HttpStatus.BAD_REQUEST);
+    NOT_REPLY_WRITER("대댓글 작성자만 수정할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    NOT_COMMENT_WRITER("댓글은 작성자만 수정할 수 있습니다.",HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ecloth/beta/domain/post/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/repository/CommentCustomRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CommentCustomRepository {
-
     Page<Comment> findByPostingIdJoinedWithMemberAndReply(Long postingId, Pageable pageable);
+    Page<Comment> findByPostingIdJoinedWithMember(Long postingId, Pageable pageable);
 
 }

--- a/src/main/java/com/ecloth/beta/domain/post/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/repository/CommentCustomRepositoryImpl.java
@@ -51,6 +51,30 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
         return new PageImpl<>(commentList, pageable, total);
     }
 
+    @Override
+    public Page<Comment> findByPostingIdJoinedWithMember(Long postingId, Pageable pageable) {
+        QComment comment = QComment.comment;
+        QMember member = QMember.member;
+
+        List<Comment> commentList = jpaQueryFactory
+                .selectFrom(comment)
+                .join(comment.writer, member)
+                .fetchJoin()
+                .where(comment.posting.postingId.eq(postingId))
+                .orderBy(getOrderSpecifier(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
+                .offset(pageable.getPageNumber() - 1)
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.posting.postingId.eq(postingId))
+                .fetchOne();
+
+        return new PageImpl<>(commentList, pageable, total);
+    }
+
     private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
 
         List<OrderSpecifier> orders = new ArrayList<>();

--- a/src/main/java/com/ecloth/beta/domain/post/comment/service/CommentService.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/service/CommentService.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.ecloth.beta.domain.post.comment.exception.ErrorCode.COMMENT_NOT_FOUND;
+import static com.ecloth.beta.domain.post.comment.exception.ErrorCode.NOT_COMMENT_WRITER;
 import static com.ecloth.beta.domain.post.posting.exception.ErrorCode.POSTING_NOT_FOUND;
 
 @Service
@@ -71,6 +72,11 @@ public class CommentService {
 
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
+
+        // 댓글 작성자와 request 작성자 id 비교
+        if (!comment.getWriter().getMemberId().equals(commentRequest.getMemberId())) {
+            throw new CommentException(NOT_COMMENT_WRITER);
+        }
 
         comment.updateContent(commentRequest.getContent());
         commentRepository.save(comment);

--- a/src/main/java/com/ecloth/beta/domain/post/comment/service/CommentService.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/service/CommentService.java
@@ -2,20 +2,21 @@ package com.ecloth.beta.domain.post.comment.service;
 
 import com.ecloth.beta.domain.member.entity.Member;
 import com.ecloth.beta.domain.member.repository.MemberRepository;
-import com.ecloth.beta.domain.post.comment.dto.CommentRequest;
-import com.ecloth.beta.domain.post.comment.dto.CommentResponse;
+import com.ecloth.beta.domain.post.comment.dto.*;
 import com.ecloth.beta.domain.post.comment.entity.Comment;
 import com.ecloth.beta.domain.post.comment.exception.CommentException;
-import com.ecloth.beta.domain.post.comment.dto.CommentListRequest;
-import com.ecloth.beta.domain.post.comment.dto.CommentListResponse;
-import com.ecloth.beta.domain.post.posting.entity.Posting;
 import com.ecloth.beta.domain.post.comment.repository.CommentRepository;
+import com.ecloth.beta.domain.post.posting.entity.Posting;
 import com.ecloth.beta.domain.post.posting.exception.PostingException;
 import com.ecloth.beta.domain.post.posting.repository.PostingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.ecloth.beta.domain.post.comment.exception.ErrorCode.COMMENT_NOT_FOUND;
 import static com.ecloth.beta.domain.post.posting.exception.ErrorCode.POSTING_NOT_FOUND;
 
@@ -37,17 +38,32 @@ public class CommentService {
                 .orElseThrow(() -> new UsernameNotFoundException("Member not Found"));
 
         Comment newComment = commentRepository.save(request.toComment(posting, writer));
-
         return CommentResponse.fromEntity(newComment, writer);
     }
 
-    // 댓글 정보 조회 * 포스트의 댓글, 답글까지 모두 한 번에 조회
+    // 댓글 정보 조회 * 포스트의 댓글, 답글까지 모두 한 번에 조회, 답글 없는경우 댓글만 조회
     public CommentListResponse getCommentListByPostingId(Long postingId, CommentListRequest request) {
 
-        Page<Comment> commentPage
-                = commentRepository.findByPostingIdJoinedWithMemberAndReply(postingId, request.toCustomPage().toPageable());
+        Page<Comment> commentPage;
 
-        return CommentListResponse.fromEntity(commentPage);
+        if (request.getSortBy().equals("registerDate") && request.getSortOrder().equals("ASC")) {
+            commentPage = commentRepository.findByPostingIdJoinedWithMember(postingId, request.toCustomPage().toPageable());
+        } else {
+            commentPage = commentRepository.findByPostingIdJoinedWithMemberAndReply(postingId, request.toCustomPage().toPageable());
+        }
+
+        List<CommentResponse> commentList = new ArrayList<>();
+        for (Comment comment : commentPage) {
+            CommentResponse response = CommentResponse.fromEntity(comment);
+            if (comment.getReply() != null) {
+                ReplyResponse replyResponse = ReplyResponse.fromEntity(comment.getReply());
+                response.setReply(replyResponse);
+            } else {
+                response.setReply(null); // reply 필드가 null인 경우에는 null로 설정
+            }
+            commentList.add(response);
+        }
+        return CommentListResponse.from(commentList, (int) commentPage.getTotalElements(), request.toCustomPage());
     }
 
     // 댓글 수정

--- a/src/main/java/com/ecloth/beta/domain/post/comment/service/ReplyService.java
+++ b/src/main/java/com/ecloth/beta/domain/post/comment/service/ReplyService.java
@@ -14,11 +14,13 @@ import com.ecloth.beta.domain.post.comment.repository.CommentRepository;
 import com.ecloth.beta.domain.post.comment.repository.ReplyRepository;
 import com.ecloth.beta.domain.post.posting.repository.PostingRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ReplyService {
 
@@ -35,6 +37,7 @@ public class ReplyService {
 
         Member replyWriter = memberRepository.findById(replyRequest.getMemberId())
                 .orElseThrow(() -> new CommentException(ErrorCode.REPLY_NOT_FOUND));
+        log.info("대댓글 요청자 ID : "+ replyRequest.getMemberId());
 
         validateIfPostingWriterAndReplyWriterMatching(parentComment, replyWriter);
 
@@ -45,11 +48,14 @@ public class ReplyService {
 
     private void validateIfPostingWriterAndReplyWriterMatching(Comment parentComment, Member replyWriter) {
 
-        Long postingWriterId = parentComment.getPosting().getWriter().getMemberId();
+        Long postingId = parentComment.getPosting().getPostingId();
         Long replyWriterId = replyWriter.getMemberId();
+        log.info("게시물ID : " +postingId + ",   대댓글작성요청자 : "+replyWriterId);
 
         boolean isPostingWriterAndReplyWriterMatching
-                = postingRepository.isPostingWriterAndReplyWriterMatching(postingWriterId, replyWriterId);
+                = postingRepository.isPostingWriterAndReplyWriterMatching(postingId, replyWriterId);
+
+        log.info("게시물작성자와 대댓글요청자 일치여부 확인 : " + isPostingWriterAndReplyWriterMatching);
 
         if (!isPostingWriterAndReplyWriterMatching) {
             throw new CommentException(ErrorCode.POSTING_WRITER_REPLY_WRITER_NOT_MATCHING);

--- a/src/main/java/com/ecloth/beta/domain/post/posting/controller/MemberPostingController.java
+++ b/src/main/java/com/ecloth/beta/domain/post/posting/controller/MemberPostingController.java
@@ -3,6 +3,7 @@ package com.ecloth.beta.domain.post.posting.controller;
 import com.ecloth.beta.domain.post.posting.dto.MemberPostingListRequest;
 import com.ecloth.beta.domain.post.posting.dto.MemberPostingListResponse;
 import com.ecloth.beta.domain.post.posting.service.PostingService;
+import com.ecloth.beta.security.memberDetail.MemberDetails;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,11 +15,7 @@ import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
 
-/**
- * 개인 피드 API
- * - (협의 필요) 마이페이지 > 개인 피드
- * - 회원의 개인 피드
- */
+
 @RestController
 @RequestMapping("/api/member")
 @Api(tags = "개인 피드 API")
@@ -28,9 +25,9 @@ public class MemberPostingController {
     private final PostingService postingService;
 
     @GetMapping("/post")
-    public ResponseEntity<MemberPostingListResponse> memberPostList(@ApiIgnore @AuthenticationPrincipal Principal principal,
+    public ResponseEntity<MemberPostingListResponse> memberPostList(@ApiIgnore @AuthenticationPrincipal MemberDetails memberDetails,
                                                                     MemberPostingListRequest request) {
-        Long memberId = Long.valueOf(principal.getName());
+        Long memberId = memberDetails.getMemberId();
         MemberPostingListResponse response = postingService.getMemberPostList(memberId, request);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/ecloth/beta/domain/post/posting/dto/MemberPostingListRequest.java
+++ b/src/main/java/com/ecloth/beta/domain/post/posting/dto/MemberPostingListRequest.java
@@ -1,11 +1,14 @@
 package com.ecloth.beta.domain.post.posting.dto;
 
 import com.ecloth.beta.common.page.CustomPage;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class MemberPostingListRequest extends CustomPage{
     public MemberPostingListRequest(int page, int size, String sortBy, String sortOrder, Long memberId) {
         super(page, size, sortBy, sortOrder);


### PR DESCRIPTION
**Changes**
---
comment 생성 : CommentResponse 대댓글 없는 경우 NullPointerException 예외 처리
comment 조회 수정
comment update 수정
reply 생성서비스 로직 수정

**AS-IS**
- comment 조회 : reply가 있는 comment만 조회가능
- comment update : 댓글 작성자가 아니어도 수정가능
- reply 생성: 게시물 memberId 와 수정 요청자 일치여부 확인 오류

**TO-BE**
- comment 조회 : reply가 없는 comment도 조회가능
- comment update : 댓글 작성자만 수정가능
- reply 생성: 서비스 로직 내 postingId 와 replyWriterId 로 ID 매칭 확인

### **테스트**
- [x]  API 테스트 (* 컨트롤러 테스트)